### PR TITLE
Handle case of non-fellow slack users

### DIFF
--- a/lib/andelan.js
+++ b/lib/andelan.js
@@ -4,7 +4,7 @@ import * as attachments from './attachments';
 
 dotenv.config();
 
-axios.defaults.headers.common = { Authorization: `Bearer ${process.env.API_TOKEN}` };
+axios.defaults.headers.common = { 'api-token': process.env.API_TOKEN };
 axios.defaults.baseURL = process.env.API_BASE_URL;
 
 export default class Andelan {
@@ -41,6 +41,7 @@ export default class Andelan {
   }
 
   get skills() {
+    if (!this.userSkills) return null;
     const {
       apprenticeship_stack: apprenticeshipStack,
       pluralsight,
@@ -74,5 +75,9 @@ export default class Andelan {
     return axios
       .get(`api/v1/skills/tech/developerskills/${id}`)
       .then(response => response.data.skills);
+  }
+
+  static isFellow(roles) {
+    return roles.map(role => role.name.toLowerCase()).includes('fellow');
   }
 }

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -1,6 +1,8 @@
 import slackifyHtml from 'slackify-html';
 
-const removeEmptyFields = fields => fields.filter(field => field.value.trim() && field.value.toLowerCase() !== 'n/a');
+const removeEmptyFields = fields => (
+  fields.filter(field => field.value && field.value.trim() && field.value.toLowerCase() !== 'n/a')
+);
 
 const capitalize = word => `${word[0].toUpperCase()}${word.substr(1)}`;
 
@@ -16,7 +18,7 @@ export const profileTemplate = (profile) => {
     fields: removeEmptyFields([
       {
         title: 'Cohort',
-        value: `${cohort.name}`,
+        value: cohort && `${cohort.name}`,
         short: true,
       },
       {
@@ -36,7 +38,7 @@ export const profileTemplate = (profile) => {
       },
       {
         title: 'D-Level',
-        value: `${level.name}`,
+        value: level && `${level.name}`,
         short: true,
       },
       {

--- a/server.js
+++ b/server.js
@@ -15,21 +15,9 @@ server.post('/slash-command',
   middlewares.validateSlashCommand,
   middlewares.extractSubCommands,
   middlewares.getUserMail,
+  middlewares.getUserInfo,
   async (req, res) => {
-    let userData;
-    let userSkills;
-    try {
-      userData = await Andelan.getUserWithEmail(res.locals.userEmail);
-      if (!userData) {
-        return middlewares.badResponse(
-          req.body.response_url,
-          'Sorry :disappointed:, this user does not have a profile on AIS.',
-        );
-      }
-      userSkills = await Andelan.getSkillsWithId(userData.id);
-    } catch (error) {
-      return middlewares.badResponse(req.body.response_url, ':cry: Something went wrong');
-    }
+    const { userData, userSkills } = res.locals;
     const andelan = new Andelan(userData, userSkills);
     const slackResponse = { attachments: [] };
     res.locals.subCommands.forEach(command => slackResponse.attachments.push(andelan[command]));


### PR DESCRIPTION
### What does this PR do
- add a static method `isFellow` to class Andelan
- extract the logic of fetching user info into a middleware
- update the logic of fetching user info to account for non-fellows

### How should it manually tested
- Clone and set up the project
- Check out to the branch containing the changes in this PR
- In the slack workspace, use `/<the-slash-command> @<slack-handle-of-non-fellow>` to test the implementation. You should get back the `profile` and `bio` of the slack user.
- You can also make use of sub-commands if you want:
- -  `/<the-slash-command> @<slack-handle-of-non-fellow> profile`
- -  `/<the-slash-command> @<slack-handle-of-non-fellow> bio`
- NOTE that you can't query for the **_placement_** or **_skills_** of a non-fellow